### PR TITLE
fix: HLS parsing for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "types": "./dist/index.d.ts"
   },
   "dependencies": {
-    "m3u-parser-generator": "^1.2.0",
+    "m3u-parser-generator": "ducktrshessami/m3u-parser-generator#dist",
     "undici": "^5.22.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "types": "./dist/index.d.ts"
   },
   "dependencies": {
-    "parse-hls": "^1.0.7",
+    "m3u-parser-generator": "^1.2.0",
     "undici": "^5.22.0"
   },
   "devDependencies": {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import HLS from "parse-hls";
+import { M3uParser } from "m3u-parser-generator";
 import { PassThrough, Readable } from "stream";
 import {
     request,
@@ -39,9 +39,9 @@ const OPTION_WEIGHT = {
 
 async function streamHls(url: URL, output: PassThrough): Promise<Readable> {
     const hlsRes = await request(url);
-    const { segments } = HLS.parse(await hlsRes.body.text());
-    for (const segment of segments) {
-        await streamThrough(new URL(segment.uri), output, false);
+    const { medias } = M3uParser.parse(await hlsRes.body.text());
+    for (const media of medias) {
+        await streamThrough(new URL(media.location), output, false);
     }
     return output.end();
 }

--- a/test/authorized.test.js
+++ b/test/authorized.test.js
@@ -49,6 +49,13 @@ describe("track", function () {
             this.timeout(5000);
             info = await scdl.getInfo(URL);
         });
+        it("can stream both progressive and hls", async function () {
+            this.timeout(5000);
+            await Promise.all([
+                scdl.streamFromInfo(info, { protocol: scdl.Protocol.PROGRESSIVE }),
+                scdl.streamFromInfo(info, { protocol: scdl.Protocol.HLS })
+            ]);
+        });
         it("info is wrapped in data object for symmetry", function () {
             assert(info.data);
             assert(info.data.id);

--- a/test/authorized.test.js
+++ b/test/authorized.test.js
@@ -17,111 +17,113 @@ function playlistTrackEmitRace(emitter, event) {
     });
 }
 
-before("fetching clientID", async function () {
-    this.timeout(5000);
-    scdl.setClientID(await fetchKey());
-});
+describe("CJS", function () {
+    before("fetching clientID", async function () {
+        this.timeout(5000);
+        scdl.setClientID(await fetchKey());
+    });
 
-describe("track", function () {
-    const URL = process.env.TRACK_URL || TRACK_URL;
-    if (!URL) {
-        console.warn("TRACK_URL not found. Skipping track tests.");
-        return;
-    }
-    it("stream readable has transcoding property", async function () {
-        this.timeout(5000);
-        const output = await scdl.stream(URL);
-        assert.strictEqual(typeof output.transcoding, "object");
-    });
-    it("streamSync emits transcoding", function (done) {
-        this.timeout(5000);
-        const output = scdl.streamSync(URL);
-        output.once("transcoding", () => done());
-    });
-    it("streamSync populates with data", function (done) {
-        this.timeout(5000);
-        const output = scdl.streamSync(URL);
-        output.once("data", () => done());
-    });
-    describe("from info", function () {
-        let info;
-        before("fetching info", async function () {
+    describe("track", function () {
+        const URL = process.env.TRACK_URL || TRACK_URL;
+        if (!URL) {
+            console.warn("TRACK_URL not found. Skipping track tests.");
+            return;
+        }
+        it("stream readable has transcoding property", async function () {
             this.timeout(5000);
-            info = await scdl.getInfo(URL);
-        });
-        it("can stream both progressive and hls", async function () {
-            this.timeout(5000);
-            await Promise.all([
-                scdl.streamFromInfo(info, { protocol: scdl.Protocol.PROGRESSIVE }),
-                scdl.streamFromInfo(info, { protocol: scdl.Protocol.HLS })
-            ]);
-        });
-        it("info is wrapped in data object for symmetry", function () {
-            assert(info.data);
-            assert(info.data.id);
-        });
-        it("streamFromInfo readable has transcoding property", async function () {
-            this.timeout(5000);
-            const output = await scdl.streamFromInfo(info);
+            const output = await scdl.stream(URL);
             assert.strictEqual(typeof output.transcoding, "object");
         });
-        it("streamFromInfoSync stream emits transcoding", function (done) {
+        it("streamSync emits transcoding", function (done) {
             this.timeout(5000);
-            const output = scdl.streamFromInfoSync(info);
+            const output = scdl.streamSync(URL);
             output.once("transcoding", () => done());
         });
-        it("streamFromInfoSync stream populates with data", function (done) {
+        it("streamSync populates with data", function (done) {
             this.timeout(5000);
-            const output = scdl.streamFromInfoSync(info);
+            const output = scdl.streamSync(URL);
             output.once("data", () => done());
         });
+        describe("from info", function () {
+            let info;
+            before("fetching info", async function () {
+                this.timeout(5000);
+                info = await scdl.getInfo(URL);
+            });
+            it("can stream both progressive and hls", async function () {
+                this.timeout(5000);
+                await Promise.all([
+                    scdl.streamFromInfo(info, { protocol: scdl.Protocol.PROGRESSIVE }),
+                    scdl.streamFromInfo(info, { protocol: scdl.Protocol.HLS })
+                ]);
+            });
+            it("info is wrapped in data object for symmetry", function () {
+                assert(info.data);
+                assert(info.data.id);
+            });
+            it("streamFromInfo readable has transcoding property", async function () {
+                this.timeout(5000);
+                const output = await scdl.streamFromInfo(info);
+                assert.strictEqual(typeof output.transcoding, "object");
+            });
+            it("streamFromInfoSync stream emits transcoding", function (done) {
+                this.timeout(5000);
+                const output = scdl.streamFromInfoSync(info);
+                output.once("transcoding", () => done());
+            });
+            it("streamFromInfoSync stream populates with data", function (done) {
+                this.timeout(5000);
+                const output = scdl.streamFromInfoSync(info);
+                output.once("data", () => done());
+            });
+        });
     });
-});
 
-describe("playlist", function () {
-    const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
-    if (!URL) {
-        console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
-        return;
-    }
-    it("streamPlaylist readables have transcoding property", async function () {
-        this.timeout(60000);
-        const result = await scdl.streamPlaylist(URL);
-        assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
-    });
-    describe("from info", function () {
-        let info;
-        before("fetching info", async function () {
-            this.timeout(5000);
-            info = await scdl.getPlaylistInfo(URL);
-        });
-        it("fetchPartialPlaylist works as intended", async function () {
+    describe("playlist", function () {
+        const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
+        if (!URL) {
+            console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
+            return;
+        }
+        it("streamPlaylist readables have transcoding property", async function () {
             this.timeout(60000);
-            if (scdl.isPlaylistFetched(info)) {
-                console.warn("All track data already present. Skipping fetchPartialPlaylist test.");
-                return;
-            }
-            await scdl.fetchPartialPlaylist(info);
-            assert.strictEqual(scdl.isPlaylistFetched(info), true);
-        });
-        it("streamPlaylistFromInfo readables have transcoding property", async function () {
-            this.timeout(60000);
-            const result = await scdl.streamPlaylistFromInfo(info);
+            const result = await scdl.streamPlaylist(URL);
             assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
         });
-        it("streamPlaylistFromInfoSync streams emit transcoding", async function () {
-            this.timeout(60000);
-            const output = scdl.streamPlaylistFromInfoSync(info);
-            await Promise.all(
-                output.map(stream => playlistTrackEmitRace(stream, "transcoding"))
-            );
-        });
-        it("streamPlaylistFromInfoSync streams populate with data", async function () {
-            this.timeout(60000);
-            const output = scdl.streamPlaylistFromInfoSync(info);
-            await Promise.all(
-                output.map(stream => playlistTrackEmitRace(stream, "data"))
-            );
+        describe("from info", function () {
+            let info;
+            before("fetching info", async function () {
+                this.timeout(5000);
+                info = await scdl.getPlaylistInfo(URL);
+            });
+            it("fetchPartialPlaylist works as intended", async function () {
+                this.timeout(60000);
+                if (scdl.isPlaylistFetched(info)) {
+                    console.warn("All track data already present. Skipping fetchPartialPlaylist test.");
+                    return;
+                }
+                await scdl.fetchPartialPlaylist(info);
+                assert.strictEqual(scdl.isPlaylistFetched(info), true);
+            });
+            it("streamPlaylistFromInfo readables have transcoding property", async function () {
+                this.timeout(60000);
+                const result = await scdl.streamPlaylistFromInfo(info);
+                assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
+            });
+            it("streamPlaylistFromInfoSync streams emit transcoding", async function () {
+                this.timeout(60000);
+                const output = scdl.streamPlaylistFromInfoSync(info);
+                await Promise.all(
+                    output.map(stream => playlistTrackEmitRace(stream, "transcoding"))
+                );
+            });
+            it("streamPlaylistFromInfoSync streams populate with data", async function () {
+                this.timeout(60000);
+                const output = scdl.streamPlaylistFromInfoSync(info);
+                await Promise.all(
+                    output.map(stream => playlistTrackEmitRace(stream, "data"))
+                );
+            });
         });
     });
 });

--- a/test/authorized.test.mjs
+++ b/test/authorized.test.mjs
@@ -1,0 +1,127 @@
+import assert from "assert";
+import { fetchKey } from "soundcloud-key-fetch";
+import * as scdl from "../dist/index.mjs";
+import { TRACK_URL, PLAYLIST_URL } from "./urls.js";
+
+function playlistTrackEmitRace(emitter, event) {
+    return new Promise(resolve => {
+        const callback = () => {
+            emitter
+                .off("error", callback)
+                .off(event, callback);
+            resolve();
+        };
+        emitter
+            .once("error", callback)
+            .once(event, callback);
+    });
+}
+
+before("fetching clientID", async function () {
+    this.timeout(5000);
+    scdl.setClientID(await fetchKey());
+});
+
+describe("track", function () {
+    const URL = process.env.TRACK_URL || TRACK_URL;
+    if (!URL) {
+        console.warn("TRACK_URL not found. Skipping track tests.");
+        return;
+    }
+    it("stream readable has transcoding property", async function () {
+        this.timeout(5000);
+        const output = await scdl.stream(URL);
+        assert.strictEqual(typeof output.transcoding, "object");
+    });
+    it("streamSync emits transcoding", function (done) {
+        this.timeout(5000);
+        const output = scdl.streamSync(URL);
+        output.once("transcoding", () => done());
+    });
+    it("streamSync populates with data", function (done) {
+        this.timeout(5000);
+        const output = scdl.streamSync(URL);
+        output.once("data", () => done());
+    });
+    describe("from info", function () {
+        let info;
+        before("fetching info", async function () {
+            this.timeout(5000);
+            info = await scdl.getInfo(URL);
+        });
+        it("can stream both progressive and hls", async function () {
+            this.timeout(5000);
+            await Promise.all([
+                scdl.streamFromInfo(info, { protocol: scdl.Protocol.PROGRESSIVE }),
+                scdl.streamFromInfo(info, { protocol: scdl.Protocol.HLS })
+            ]);
+        });
+        it("info is wrapped in data object for symmetry", function () {
+            assert(info.data);
+            assert(info.data.id);
+        });
+        it("streamFromInfo readable has transcoding property", async function () {
+            this.timeout(5000);
+            const output = await scdl.streamFromInfo(info);
+            assert.strictEqual(typeof output.transcoding, "object");
+        });
+        it("streamFromInfoSync stream emits transcoding", function (done) {
+            this.timeout(5000);
+            const output = scdl.streamFromInfoSync(info);
+            output.once("transcoding", () => done());
+        });
+        it("streamFromInfoSync stream populates with data", function (done) {
+            this.timeout(5000);
+            const output = scdl.streamFromInfoSync(info);
+            output.once("data", () => done());
+        });
+    });
+});
+
+describe("playlist", function () {
+    const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
+    if (!URL) {
+        console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
+        return;
+    }
+    it("streamPlaylist readables have transcoding property", async function () {
+        this.timeout(60000);
+        const result = await scdl.streamPlaylist(URL);
+        assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
+    });
+    describe("from info", function () {
+        let info;
+        before("fetching info", async function () {
+            this.timeout(5000);
+            info = await scdl.getPlaylistInfo(URL);
+        });
+        it("fetchPartialPlaylist works as intended", async function () {
+            this.timeout(60000);
+            if (scdl.isPlaylistFetched(info)) {
+                console.warn("All track data already present. Skipping fetchPartialPlaylist test.");
+                return;
+            }
+            await scdl.fetchPartialPlaylist(info);
+            assert.strictEqual(scdl.isPlaylistFetched(info), true);
+        });
+        it("streamPlaylistFromInfo readables have transcoding property", async function () {
+            this.timeout(60000);
+            const result = await scdl.streamPlaylistFromInfo(info);
+            assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
+        });
+        it("streamPlaylistFromInfoSync streams emit transcoding", async function () {
+            this.timeout(60000);
+            const output = scdl.streamPlaylistFromInfoSync(info);
+            await Promise.all(
+                output.map(stream => playlistTrackEmitRace(stream, "transcoding"))
+            );
+        });
+        it("streamPlaylistFromInfoSync streams populate with data", async function () {
+            this.timeout(60000);
+            const output = scdl.streamPlaylistFromInfoSync(info);
+            await Promise.all(
+                output.map(stream => playlistTrackEmitRace(stream, "data"))
+            );
+        });
+    });
+});

--- a/test/authorized.test.mjs
+++ b/test/authorized.test.mjs
@@ -17,111 +17,113 @@ function playlistTrackEmitRace(emitter, event) {
     });
 }
 
-before("fetching clientID", async function () {
-    this.timeout(5000);
-    scdl.setClientID(await fetchKey());
-});
+describe("ESM", function () {
+    before("fetching clientID", async function () {
+        this.timeout(5000);
+        scdl.setClientID(await fetchKey());
+    });
 
-describe("track", function () {
-    const URL = process.env.TRACK_URL || TRACK_URL;
-    if (!URL) {
-        console.warn("TRACK_URL not found. Skipping track tests.");
-        return;
-    }
-    it("stream readable has transcoding property", async function () {
-        this.timeout(5000);
-        const output = await scdl.stream(URL);
-        assert.strictEqual(typeof output.transcoding, "object");
-    });
-    it("streamSync emits transcoding", function (done) {
-        this.timeout(5000);
-        const output = scdl.streamSync(URL);
-        output.once("transcoding", () => done());
-    });
-    it("streamSync populates with data", function (done) {
-        this.timeout(5000);
-        const output = scdl.streamSync(URL);
-        output.once("data", () => done());
-    });
-    describe("from info", function () {
-        let info;
-        before("fetching info", async function () {
+    describe("track", function () {
+        const URL = process.env.TRACK_URL || TRACK_URL;
+        if (!URL) {
+            console.warn("TRACK_URL not found. Skipping track tests.");
+            return;
+        }
+        it("stream readable has transcoding property", async function () {
             this.timeout(5000);
-            info = await scdl.getInfo(URL);
-        });
-        it("can stream both progressive and hls", async function () {
-            this.timeout(5000);
-            await Promise.all([
-                scdl.streamFromInfo(info, { protocol: scdl.Protocol.PROGRESSIVE }),
-                scdl.streamFromInfo(info, { protocol: scdl.Protocol.HLS })
-            ]);
-        });
-        it("info is wrapped in data object for symmetry", function () {
-            assert(info.data);
-            assert(info.data.id);
-        });
-        it("streamFromInfo readable has transcoding property", async function () {
-            this.timeout(5000);
-            const output = await scdl.streamFromInfo(info);
+            const output = await scdl.stream(URL);
             assert.strictEqual(typeof output.transcoding, "object");
         });
-        it("streamFromInfoSync stream emits transcoding", function (done) {
+        it("streamSync emits transcoding", function (done) {
             this.timeout(5000);
-            const output = scdl.streamFromInfoSync(info);
+            const output = scdl.streamSync(URL);
             output.once("transcoding", () => done());
         });
-        it("streamFromInfoSync stream populates with data", function (done) {
+        it("streamSync populates with data", function (done) {
             this.timeout(5000);
-            const output = scdl.streamFromInfoSync(info);
+            const output = scdl.streamSync(URL);
             output.once("data", () => done());
         });
+        describe("from info", function () {
+            let info;
+            before("fetching info", async function () {
+                this.timeout(5000);
+                info = await scdl.getInfo(URL);
+            });
+            it("can stream both progressive and hls", async function () {
+                this.timeout(5000);
+                await Promise.all([
+                    scdl.streamFromInfo(info, { protocol: scdl.Protocol.PROGRESSIVE }),
+                    scdl.streamFromInfo(info, { protocol: scdl.Protocol.HLS })
+                ]);
+            });
+            it("info is wrapped in data object for symmetry", function () {
+                assert(info.data);
+                assert(info.data.id);
+            });
+            it("streamFromInfo readable has transcoding property", async function () {
+                this.timeout(5000);
+                const output = await scdl.streamFromInfo(info);
+                assert.strictEqual(typeof output.transcoding, "object");
+            });
+            it("streamFromInfoSync stream emits transcoding", function (done) {
+                this.timeout(5000);
+                const output = scdl.streamFromInfoSync(info);
+                output.once("transcoding", () => done());
+            });
+            it("streamFromInfoSync stream populates with data", function (done) {
+                this.timeout(5000);
+                const output = scdl.streamFromInfoSync(info);
+                output.once("data", () => done());
+            });
+        });
     });
-});
 
-describe("playlist", function () {
-    const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
-    if (!URL) {
-        console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
-        return;
-    }
-    it("streamPlaylist readables have transcoding property", async function () {
-        this.timeout(60000);
-        const result = await scdl.streamPlaylist(URL);
-        assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
-    });
-    describe("from info", function () {
-        let info;
-        before("fetching info", async function () {
-            this.timeout(5000);
-            info = await scdl.getPlaylistInfo(URL);
-        });
-        it("fetchPartialPlaylist works as intended", async function () {
+    describe("playlist", function () {
+        const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
+        if (!URL) {
+            console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
+            return;
+        }
+        it("streamPlaylist readables have transcoding property", async function () {
             this.timeout(60000);
-            if (scdl.isPlaylistFetched(info)) {
-                console.warn("All track data already present. Skipping fetchPartialPlaylist test.");
-                return;
-            }
-            await scdl.fetchPartialPlaylist(info);
-            assert.strictEqual(scdl.isPlaylistFetched(info), true);
-        });
-        it("streamPlaylistFromInfo readables have transcoding property", async function () {
-            this.timeout(60000);
-            const result = await scdl.streamPlaylistFromInfo(info);
+            const result = await scdl.streamPlaylist(URL);
             assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
         });
-        it("streamPlaylistFromInfoSync streams emit transcoding", async function () {
-            this.timeout(60000);
-            const output = scdl.streamPlaylistFromInfoSync(info);
-            await Promise.all(
-                output.map(stream => playlistTrackEmitRace(stream, "transcoding"))
-            );
-        });
-        it("streamPlaylistFromInfoSync streams populate with data", async function () {
-            this.timeout(60000);
-            const output = scdl.streamPlaylistFromInfoSync(info);
-            await Promise.all(
-                output.map(stream => playlistTrackEmitRace(stream, "data"))
-            );
+        describe("from info", function () {
+            let info;
+            before("fetching info", async function () {
+                this.timeout(5000);
+                info = await scdl.getPlaylistInfo(URL);
+            });
+            it("fetchPartialPlaylist works as intended", async function () {
+                this.timeout(60000);
+                if (scdl.isPlaylistFetched(info)) {
+                    console.warn("All track data already present. Skipping fetchPartialPlaylist test.");
+                    return;
+                }
+                await scdl.fetchPartialPlaylist(info);
+                assert.strictEqual(scdl.isPlaylistFetched(info), true);
+            });
+            it("streamPlaylistFromInfo readables have transcoding property", async function () {
+                this.timeout(60000);
+                const result = await scdl.streamPlaylistFromInfo(info);
+                assert.strictEqual(result.every(item => item === null || typeof item.transcoding === "object"), true);
+            });
+            it("streamPlaylistFromInfoSync streams emit transcoding", async function () {
+                this.timeout(60000);
+                const output = scdl.streamPlaylistFromInfoSync(info);
+                await Promise.all(
+                    output.map(stream => playlistTrackEmitRace(stream, "transcoding"))
+                );
+            });
+            it("streamPlaylistFromInfoSync streams populate with data", async function () {
+                this.timeout(60000);
+                const output = scdl.streamPlaylistFromInfoSync(info);
+                await Promise.all(
+                    output.map(stream => playlistTrackEmitRace(stream, "data"))
+                );
+            });
         });
     });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,46 +2,48 @@ const assert = require("assert");
 const scdl = require("../dist");
 const { TRACK_URL, PLAYLIST_URL } = require("./urls");
 
-describe("track", function () {
-    const URL = process.env.TRACK_URL || TRACK_URL;
-    if (!URL) {
-        console.warn("TRACK_URL not found. Skipping track tests.");
-        return;
-    }
-    it("TrackURLPattern matches groups properly", function () {
-        const result = URL.match(scdl.TrackURLPattern);
-        assert(result);
-        assert.strictEqual(typeof result.groups?.user, "string");
-        assert.strictEqual(typeof result.groups?.title, "string");
+describe("CJS", function () {
+    describe("track", function () {
+        const URL = process.env.TRACK_URL || TRACK_URL;
+        if (!URL) {
+            console.warn("TRACK_URL not found. Skipping track tests.");
+            return;
+        }
+        it("TrackURLPattern matches groups properly", function () {
+            const result = URL.match(scdl.TrackURLPattern);
+            assert(result);
+            assert.strictEqual(typeof result.groups?.user, "string");
+            assert.strictEqual(typeof result.groups?.title, "string");
+        });
+        it("validateURL sync checks format", function () {
+            assert.strictEqual(scdl.validateURL(URL), true);
+            assert.strictEqual(scdl.validateURL("https://soundcloud.com/"), false);
+        });
+        it("getPermalinkURL always string", function () {
+            assert.strictEqual(typeof scdl.getPermalinkURL(URL), "string");
+            assert.strictEqual(typeof scdl.getPermalinkURL("foobar"), "string");
+        });
     });
-    it("validateURL sync checks format", function () {
-        assert.strictEqual(scdl.validateURL(URL), true);
-        assert.strictEqual(scdl.validateURL("https://soundcloud.com/"), false);
-    });
-    it("getPermalinkURL always string", function () {
-        assert.strictEqual(typeof scdl.getPermalinkURL(URL), "string");
-        assert.strictEqual(typeof scdl.getPermalinkURL("foobar"), "string");
-    });
-});
 
-describe("playlist", function () {
-    const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
-    if (!URL) {
-        console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
-        return;
-    }
-    it("PlaylistURLPattern matches groups properly", function () {
-        const result = URL.match(scdl.PlaylistURLPattern);
-        assert(result);
-        assert.strictEqual(typeof result.groups?.user, "string");
-        assert.strictEqual(typeof result.groups?.title, "string");
-    });
-    it("validatePlaylistURL sync checks format", function () {
-        assert.strictEqual(scdl.validatePlaylistURL(URL), true);
-        assert.strictEqual(scdl.validatePlaylistURL("https://soundcloud.com/"), false);
-    });
-    it("getPlaylistPermalinkURL always string", function () {
-        assert.strictEqual(typeof scdl.getPlaylistPermalinkURL(URL), "string");
-        assert.strictEqual(typeof scdl.getPlaylistPermalinkURL("foobar"), "string");
+    describe("playlist", function () {
+        const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
+        if (!URL) {
+            console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
+            return;
+        }
+        it("PlaylistURLPattern matches groups properly", function () {
+            const result = URL.match(scdl.PlaylistURLPattern);
+            assert(result);
+            assert.strictEqual(typeof result.groups?.user, "string");
+            assert.strictEqual(typeof result.groups?.title, "string");
+        });
+        it("validatePlaylistURL sync checks format", function () {
+            assert.strictEqual(scdl.validatePlaylistURL(URL), true);
+            assert.strictEqual(scdl.validatePlaylistURL("https://soundcloud.com/"), false);
+        });
+        it("getPlaylistPermalinkURL always string", function () {
+            assert.strictEqual(typeof scdl.getPlaylistPermalinkURL(URL), "string");
+            assert.strictEqual(typeof scdl.getPlaylistPermalinkURL("foobar"), "string");
+        });
     });
 });

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -2,46 +2,48 @@ import assert from "assert";
 import * as scdl from "../dist/index.mjs";
 import { TRACK_URL, PLAYLIST_URL } from "./urls.js";
 
-describe("track", function () {
-    const URL = process.env.TRACK_URL || TRACK_URL;
-    if (!URL) {
-        console.warn("TRACK_URL not found. Skipping track tests.");
-        return;
-    }
-    it("TrackURLPattern matches groups properly", function () {
-        const result = URL.match(scdl.TrackURLPattern);
-        assert(result);
-        assert.strictEqual(typeof result.groups?.user, "string");
-        assert.strictEqual(typeof result.groups?.title, "string");
+describe("ESM", function () {
+    describe("track", function () {
+        const URL = process.env.TRACK_URL || TRACK_URL;
+        if (!URL) {
+            console.warn("TRACK_URL not found. Skipping track tests.");
+            return;
+        }
+        it("TrackURLPattern matches groups properly", function () {
+            const result = URL.match(scdl.TrackURLPattern);
+            assert(result);
+            assert.strictEqual(typeof result.groups?.user, "string");
+            assert.strictEqual(typeof result.groups?.title, "string");
+        });
+        it("validateURL sync checks format", function () {
+            assert.strictEqual(scdl.validateURL(URL), true);
+            assert.strictEqual(scdl.validateURL("https://soundcloud.com/"), false);
+        });
+        it("getPermalinkURL always string", function () {
+            assert.strictEqual(typeof scdl.getPermalinkURL(URL), "string");
+            assert.strictEqual(typeof scdl.getPermalinkURL("foobar"), "string");
+        });
     });
-    it("validateURL sync checks format", function () {
-        assert.strictEqual(scdl.validateURL(URL), true);
-        assert.strictEqual(scdl.validateURL("https://soundcloud.com/"), false);
-    });
-    it("getPermalinkURL always string", function () {
-        assert.strictEqual(typeof scdl.getPermalinkURL(URL), "string");
-        assert.strictEqual(typeof scdl.getPermalinkURL("foobar"), "string");
-    });
-});
 
-describe("playlist", function () {
-    const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
-    if (!URL) {
-        console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
-        return;
-    }
-    it("PlaylistURLPattern matches groups properly", function () {
-        const result = URL.match(scdl.PlaylistURLPattern);
-        assert(result);
-        assert.strictEqual(typeof result.groups?.user, "string");
-        assert.strictEqual(typeof result.groups?.title, "string");
-    });
-    it("validatePlaylistURL sync checks format", function () {
-        assert.strictEqual(scdl.validatePlaylistURL(URL), true);
-        assert.strictEqual(scdl.validatePlaylistURL("https://soundcloud.com/"), false);
-    });
-    it("getPlaylistPermalinkURL always string", function () {
-        assert.strictEqual(typeof scdl.getPlaylistPermalinkURL(URL), "string");
-        assert.strictEqual(typeof scdl.getPlaylistPermalinkURL("foobar"), "string");
+    describe("playlist", function () {
+        const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
+        if (!URL) {
+            console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
+            return;
+        }
+        it("PlaylistURLPattern matches groups properly", function () {
+            const result = URL.match(scdl.PlaylistURLPattern);
+            assert(result);
+            assert.strictEqual(typeof result.groups?.user, "string");
+            assert.strictEqual(typeof result.groups?.title, "string");
+        });
+        it("validatePlaylistURL sync checks format", function () {
+            assert.strictEqual(scdl.validatePlaylistURL(URL), true);
+            assert.strictEqual(scdl.validatePlaylistURL("https://soundcloud.com/"), false);
+        });
+        it("getPlaylistPermalinkURL always string", function () {
+            assert.strictEqual(typeof scdl.getPlaylistPermalinkURL(URL), "string");
+            assert.strictEqual(typeof scdl.getPlaylistPermalinkURL("foobar"), "string");
+        });
     });
 });

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -1,0 +1,47 @@
+import assert from "assert";
+import * as scdl from "../dist/index.mjs";
+import { TRACK_URL, PLAYLIST_URL } from "./urls.js";
+
+describe("track", function () {
+    const URL = process.env.TRACK_URL || TRACK_URL;
+    if (!URL) {
+        console.warn("TRACK_URL not found. Skipping track tests.");
+        return;
+    }
+    it("TrackURLPattern matches groups properly", function () {
+        const result = URL.match(scdl.TrackURLPattern);
+        assert(result);
+        assert.strictEqual(typeof result.groups?.user, "string");
+        assert.strictEqual(typeof result.groups?.title, "string");
+    });
+    it("validateURL sync checks format", function () {
+        assert.strictEqual(scdl.validateURL(URL), true);
+        assert.strictEqual(scdl.validateURL("https://soundcloud.com/"), false);
+    });
+    it("getPermalinkURL always string", function () {
+        assert.strictEqual(typeof scdl.getPermalinkURL(URL), "string");
+        assert.strictEqual(typeof scdl.getPermalinkURL("foobar"), "string");
+    });
+});
+
+describe("playlist", function () {
+    const URL = process.env.PLAYLIST_URL || PLAYLIST_URL;
+    if (!URL) {
+        console.warn("PLAYLIST_URL not found. Skipping playlist tests.");
+        return;
+    }
+    it("PlaylistURLPattern matches groups properly", function () {
+        const result = URL.match(scdl.PlaylistURLPattern);
+        assert(result);
+        assert.strictEqual(typeof result.groups?.user, "string");
+        assert.strictEqual(typeof result.groups?.title, "string");
+    });
+    it("validatePlaylistURL sync checks format", function () {
+        assert.strictEqual(scdl.validatePlaylistURL(URL), true);
+        assert.strictEqual(scdl.validatePlaylistURL("https://soundcloud.com/"), false);
+    });
+    it("getPlaylistPermalinkURL always string", function () {
+        assert.strictEqual(typeof scdl.getPlaylistPermalinkURL(URL), "string");
+        assert.strictEqual(typeof scdl.getPlaylistPermalinkURL("foobar"), "string");
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,10 +651,9 @@ log-symbols@4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-m3u-parser-generator@^1.2.0:
+m3u-parser-generator@ducktrshessami/m3u-parser-generator#dist:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/m3u-parser-generator/-/m3u-parser-generator-1.2.0.tgz#238d4473b8bf8d355493f78dca48ae0598962b46"
-  integrity sha512-OyE/U0Irwgt4PLdOpktDuodCNEjehAVSasrczVtkf353Rxqq14KhR/HlId4564jplVXAr9qLv3tCQ9l/DTQxsg==
+  resolved "https://codeload.github.com/ducktrshessami/m3u-parser-generator/tar.gz/82d9291d42005951573f0e2df7dc1ba41e777f4e"
 
 merge-stream@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,6 +651,11 @@ log-symbols@4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+m3u-parser-generator@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/m3u-parser-generator/-/m3u-parser-generator-1.2.0.tgz#238d4473b8bf8d355493f78dca48ae0598962b46"
+  integrity sha512-OyE/U0Irwgt4PLdOpktDuodCNEjehAVSasrczVtkf353Rxqq14KhR/HlId4564jplVXAr9qLv3tCQ9l/DTQxsg==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -783,11 +788,6 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
-
-parse-hls@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/parse-hls/-/parse-hls-1.0.7.tgz#b1c437133f596b9d3ad074027aa8c05d33e9eb3c"
-  integrity sha512-tnAK2nXe8J/Jf66SwY2cUAKKXInLR9hkNhTtcS7t6J4CgkG8LGBfC1GuuXg7kLLbIQLXpVhZrY/tfyhDbqfzwg==
 
 path-exists@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
current `parse-hls` typings are inconsistent for ESM